### PR TITLE
Allow specifying random seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.1
+
+- Allow specifying random seed
+- Update dependencies
+
 ## 3.0.0
 - Remove problematic name [check](https://github.com/flutterninja9/unique_names_generator/pull/2)
 

--- a/lib/src/unique_names_generator_base.dart
+++ b/lib/src/unique_names_generator_base.dart
@@ -8,7 +8,7 @@ class UniqueNamesGenerator {
 
   UniqueNamesGenerator({required this.config});
 
-  String generate() {
+  String generate({int? randomSeed}) {
     if (config.dictionaries.isEmpty) {
       throw UniqueNamesGeneratorException(
         'Please provide a dictionary\nPossible values could be adjectives, animals, colors, countries, languages, names, starWars',
@@ -30,7 +30,7 @@ class UniqueNamesGenerator {
     final generatedList = [];
     for (int i = 0; i < config.length; i++) {
       final wordList = config.dictionaries[i];
-      String word = wordList[Random().nextInt(wordList.length)];
+      String word = wordList[Random(randomSeed).nextInt(wordList.length)];
 
       switch (config.style) {
         case Style.lowerCase:

--- a/lib/src/unique_names_generator_base.dart
+++ b/lib/src/unique_names_generator_base.dart
@@ -27,10 +27,12 @@ class UniqueNamesGenerator {
       );
     }
 
+    final random = Random(randomSeed);
+
     final generatedList = [];
     for (int i = 0; i < config.length; i++) {
       final wordList = config.dictionaries[i];
-      String word = wordList[Random(randomSeed).nextInt(wordList.length)];
+      String word = wordList[random.nextInt(wordList.length)];
 
       switch (config.style) {
         case Style.lowerCase:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: unique_names_generator
 description: Unique name generator package for generating random and unique names.
-version: 3.0.0
+version: 3.0.1
 homepage: https://www.anirudhsingh.in/
 repository: https://github.com/flutterninja9/unique_names_generator
 
 environment:
-  sdk: '>=2.16.2 <3.16.0'
+  sdk: ">=2.16.2 <3.16.0"
 
 dev_dependencies:
-  lints: ^3.0.0
-  test: ^1.16.0
+  lints: ^6.1.0
+  test: ^1.30.0


### PR DESCRIPTION
To make it possible to generate deterministic names, this PR allows the caller to specify the random seed to be used when picking words.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional seed parameter for name generation to produce reproducible results

* **Chores**
  * Bumped package version to 3.0.1 and updated development dependencies

* **Documentation**
  * Added 3.0.1 entry to changelog outlining the seed option and dependency updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->